### PR TITLE
Use plugin:// stream for resolving sandbox images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.history

--- a/templates/partials/adsense.html.twig
+++ b/templates/partials/adsense.html.twig
@@ -32,13 +32,12 @@
 
     {# Sandy Mode #}
   {% elseif adsense_mode == "sandy" %}
-  <img
-    src="{{ base_url_absolute ~ '/user/plugins/adsense2/assets/img/sandy_'~adsense_format~'.png' }}"
-    style="display:inline-block;width:{{ adsense_width }}px;height:{{ adsense_height }}px"
-    alt="Sandy Ad"
-    title="Sandy Ad"
-    class="sandy" />
-
+    <img
+      src="{{ url('plugin://adsense2/assets/img/sandy_'~adsense_format~'.png') }}"
+      style="display:inline-block;width:{{ adsense_width }}px;height:{{ adsense_height }}px"
+      alt="Sandy Ad"
+      title="Sandy Ad"
+      class="sandy" />
   {% endif %}
 
 </div>


### PR DESCRIPTION
I was having issues with the sandbox images displaying on my
development environment, and found it to be because the images couldn't
be loaded. This fix changes how the URL is constructed to allow finding
the appropriate sandbox image based on the plugin:// URL
stream/protocol instead of constructing it via the base_url_absolute
variable.

Using the plugin:// protocol appears to be a little more portable.